### PR TITLE
Google Translate RTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A CSS reset inspired by the community.
 - [Andy Bell - A Modern CSS Reset](https://piccalil.li/blog/a-more-modern-css-reset/)
 - [Josh Comeau - A Modern CSS Reset](https://www.joshwcomeau.com/css/custom-css-reset/)
 - [Kilian Valkhof - Your CSS reset needs text-size-adjust (probably)](https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/)
+- [David Bushell - Let’s see Paul Allen’s CSS Reset](https://dbushell.com/2025/09/12/css-reset/)

--- a/reset.css
+++ b/reset.css
@@ -2,6 +2,7 @@
  * A combination of the following resets:
  * https://piccalil.li/blog/a-more-modern-css-reset/
  * https://www.joshwcomeau.com/css/custom-css-reset/
+ * https://dbushell.com/2025/09/12/css-reset/
  */
 
 /* Use a more-intuitive box-sizing model. */
@@ -23,6 +24,13 @@ html {
   -webkit-text-size-adjust: none;
   /* stylelint-disable-next-line plugin/use-baseline */
   text-size-adjust: none;
+}
+
+/* Google Translate RTL support */
+
+/* https://dbushell.com/2025/09/12/css-reset/#:~:text=translated%2Drtl */
+html.translated-rtl {
+  direction: rtl;
 }
 
 /* Remove default margin in favour of better control in authored CSS */


### PR DESCRIPTION
Google Translate doesn’t add `dir="rtl"` when translating into a right-to-left script. But it adds a `translated-rtl` class to `<html>` that can be used as a CSS hook for `direction: rtl`.